### PR TITLE
BTUC-15930: Do not access NULL QScreen

### DIFF
--- a/src/controls/qquickmenupopupwindow.cpp
+++ b/src/controls/qquickmenupopupwindow.cpp
@@ -109,9 +109,11 @@ void QQuickMenuPopupWindow::setGeometry(int posx, int posy, int w, int h)
         pw = parentItem()->window();
     if (!pw)
         pw = this;
-    QRect g = pw->screen()->geometry();
+    QRect g;
+    if (pw->screen())
+        g = pw->screen()->geometry();
 
-    if (posx + w > g.right()) {
+    if (!g.isNull() && posx + w > g.right()) {
         if (qobject_cast<QQuickMenuPopupWindow *>(transientParent())) {
             // reposition submenu window on the parent menu's left side
             int submenuOverlap = pw->x() + pw->width() - posx;


### PR DESCRIPTION
Fix a random crash that happens sometimes when plugging/unplugging
monitors and a window is exposed with its screen as NULL.

Change-Id: Id32edad7a0cc5d39f840ad6b32032d314ff553b1