### PR TITLE
BTUC-17592: Increase qtquick version for label.

### DIFF
--- a/src/controls/Label.qml
+++ b/src/controls/Label.qml
@@ -34,7 +34,7 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.2
+import QtQuick 2.6
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Private 1.0
 


### PR DESCRIPTION
- QtQuick from 2.2->2.6 to get padding props. available from Text control.