### PR TITLE
BTUC-19449: Remove menubar focus hack

### DIFF
--- a/src/controls/MenuBar.qml
+++ b/src/controls/MenuBar.qml
@@ -217,12 +217,6 @@ MenuBarPrivate {
             }
         }
         property alias __altPressed: d.altPressed // Needed for the menu contents
-        signal menuBarFocusLost(var reason)
-
-        onMenuBarFocusLost:{
-            if (reason != Qt.MouseFocusReason)
-                d.dismissActiveFocus(null, true)
-        }
 
         focus: true
 


### PR DESCRIPTION
- Fix menu stealing focus from chat input.
- Was added previously to prevent focus from staying
  on menu bar even after the window loses its focus.
  Removing this fix as the original issue does not
  seem to happen even without the fix.

Change-Id: I7e8066ad0158a257a4a7f203c0ead098d51150b3